### PR TITLE
Fix issue #6: Profile picture rolls down to the middle part of the chat card

### DIFF
--- a/templates/actiroom.html
+++ b/templates/actiroom.html
@@ -96,7 +96,7 @@
                             $('div.mailhold').append
                             (
                                 '<article class="uk-comment uk-background-secondary uk-border-rounded">' +
-                                '<header class="uk-comment-header uk-grid-medium uk-flex-middle" uk-grid>' +
+                                '<header class="uk-comment-header uk-grid-medium" uk-grid>' +
                                 '<div class="uk-width-auto">' +
                                 '<img class="uk-comment-avatar uk-border-rounded" src="{{ url_for("static", filename="imgs/avtrgrfx.jpg") }}" width="80" height="80" alt="">' +
                                 '</div>' +


### PR DESCRIPTION
Fixed the position of profile pic at the top of chat card